### PR TITLE
fix: A列を自動調整

### DIFF
--- a/src/createTodoList.gs
+++ b/src/createTodoList.gs
@@ -97,6 +97,7 @@ function formatSpreadsheet(eventCount) {
     }
     
     // 列幅の調整
+    sheet.autoResizeColumn(1);    // A列：タイトル（自動調整）
     sheet.setColumnWidth(2, 400); // B列：予定内容
     sheet.setColumnWidth(3, 80);  // C列：チェックボックス
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The width of the first column in the to-do list is now automatically adjusted to fit its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->